### PR TITLE
Support for Flutter Web using Proxy URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # google_maps_places_autocomplete_widgets package
 
+## 1.3.4
+* Added support for a Proxy URL to enable Flutter Web support without CORS issues.
+* 
 ## 1.3.3
 
 * Fix dart analyze warning about using deprecated postalCodeLookup (which we use internally to allow it to continue to work

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -162,6 +162,7 @@ class _AddressAutocompleteTextFieldExampleState
                 child: AddressAutocompleteTextField(
                   type: AutoCompleteType.postalCode,
                   keyboardType: TextInputType.number,
+                  proxyUrl: PROXY_URL,
                   maxLength: 5,
                   maxLengthEnforcement: MaxLengthEnforcement.enforced,
                   style: const TextStyle(
@@ -591,6 +592,7 @@ class _AddressAutocompleteTextFormFieldExampleState
                 AddressAutocompleteTextFormField(
                   // following args specific to AddressAutocompleteTextFormField()
                   mapsApiKey: GOOGLE_MAPS_ACCOUNT_API_KEY,
+                  proxyUrl: PROXY_URL,
                   debounceTime: 200,
                   //In practice this does not seem to help United States address//prepareQuery: prepareQuery,
                   onClearClick: onClearClick,

--- a/google_maps_places_autocomplete_widgets.iml
+++ b/google_maps_places_autocomplete_widgets.iml
@@ -9,11 +9,14 @@
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/example/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/example/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/example/build" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 29 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
     <orderEntry type="library" name="Dart SDK" level="project" />
     <orderEntry type="library" name="Flutter Plugins" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/lib/api/place_api_provider.dart
+++ b/lib/api/place_api_provider.dart
@@ -104,7 +104,8 @@ result["predictions"] =
   ///   instead of address type information.
   Future<List<Suggestion>> fetchSuggestions(String input,
       {bool includeFullSuggestionDetails = false,
-      required List<AutoCompleteType> types}) async {
+      required List<AutoCompleteType> types,
+      String? proxyUrl}) async {
     /// OK, we need to check the types array..
     String typesString = '';
     for (final type in types) {
@@ -135,13 +136,33 @@ result["predictions"] =
           .addAll(<String, dynamic>{'components': 'country:$compomentCountry'});
     }
 
-    final Uri request = Uri(
-        scheme: 'https',
-        host: 'maps.googleapis.com',
-        path: '/maps/api/place/autocomplete/json',
-        queryParameters: parameters);
+    Uri request = Uri(
+      scheme: 'https',
+      host: 'maps.googleapis.com',
+      path: '/maps/api/place/autocomplete/json',
+      queryParameters: parameters,
+    );
+
+    //Add Proxy support for web
+    if (proxyUrl != null && proxyUrl.isNotEmpty) {
+      final proxyRequest = Uri.tryParse(proxyUrl) ??
+          Uri(
+            scheme: 'https',
+            host: 'maps.googleapis.com',
+            path: '/maps/api/place/autocomplete/json',
+            queryParameters: parameters,
+          );
+
+      request = Uri(
+        scheme: proxyRequest.scheme,
+        host: proxyRequest.host,
+        path: proxyRequest.path,
+        queryParameters: parameters,
+      );
+    }
 
     final response = await client.get(request);
+    debugPrint("response.body: ${response.body}");
 
     if (response.statusCode == 200) {
       final result = json.decode(response.body);

--- a/lib/api/place_api_provider.dart
+++ b/lib/api/place_api_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:google_maps_places_autocomplete_widgets/api/autocomplete_types.dart';
 import 'package:http/http.dart';
@@ -144,7 +145,7 @@ result["predictions"] =
     );
 
     //Add Proxy support for web
-    if (proxyUrl != null && proxyUrl.isNotEmpty) {
+    if ((kIsWeb || kIsWasm) && (proxyUrl != null && proxyUrl.isNotEmpty)) {
       final proxyRequest = Uri.tryParse(proxyUrl) ??
           Uri(
             scheme: 'https',
@@ -162,7 +163,6 @@ result["predictions"] =
     }
 
     final response = await client.get(request);
-    debugPrint("response.body: ${response.body}");
 
     if (response.statusCode == 200) {
       final result = json.decode(response.body);

--- a/lib/service/address_service.dart
+++ b/lib/service/address_service.dart
@@ -18,10 +18,14 @@ class AddressService {
 
   Future<List<Suggestion>> search(String query,
       {bool includeFullSuggestionDetails = false,
-      List<AutoCompleteType> types = const [AutoCompleteType.address]}) async {
-    return await apiClient.fetchSuggestions(query,
-        includeFullSuggestionDetails: includeFullSuggestionDetails,
-        types: types);
+      List<AutoCompleteType> types = const [AutoCompleteType.address],
+      String? proxyUrl}) async {
+    return await apiClient.fetchSuggestions(
+      query,
+      includeFullSuggestionDetails: includeFullSuggestionDetails,
+      types: types,
+      proxyUrl: proxyUrl,
+    );
   }
 
   Future<Place> getPlaceDetail(String placeId) async {

--- a/lib/widgets/address_autocomplete_generic.dart
+++ b/lib/widgets/address_autocomplete_generic.dart
@@ -44,6 +44,9 @@ abstract class AddresssAutocompleteStatefulWidget extends StatefulWidget {
   ///your maps api key, must not be null
   abstract final String mapsApiKey;
 
+  ///your proxy url for web
+  abstract final String? proxyUrl;
+
   ///builder used to render each item displayed
   ///must not be null
   abstract final Widget Function(Suggestion, int)? buildItem;
@@ -318,20 +321,22 @@ mixin SuggestionOverlayMixin<T extends AddresssAutocompleteStatefulWidget>
           'You can only supply value for [type], [types] (or deprecated `postalCodeLookup`).  No combinations allowed');
 
       _lastText = text;
-      suggestions = await addressService.search(text,
-          includeFullSuggestionDetails:
-              (widget.onInitialSuggestionClick != null),
-          types: [
-            if (widget.postalCodeLookup == true)
-              AutoCompleteType.postalCode
-            else if (widget.postalCodeLookup == false ||
-                (widget.type == null && widget.types == null))
-              AutoCompleteType.address
-            else if (widget.type != null)
-              widget.type!
-            else if (widget.types != null)
-              ...widget.types!
-          ]);
+      suggestions = await addressService.search(
+        text,
+        includeFullSuggestionDetails: (widget.onInitialSuggestionClick != null),
+        types: [
+          if (widget.postalCodeLookup == true)
+            AutoCompleteType.postalCode
+          else if (widget.postalCodeLookup == false ||
+              (widget.type == null && widget.types == null))
+            AutoCompleteType.address
+          else if (widget.type != null)
+            widget.type!
+          else if (widget.types != null)
+            ...widget.types!
+        ],
+        proxyUrl: widget.proxyUrl,
+      );
     }
     if (entry != null) {
       entry!.markNeedsBuild();

--- a/lib/widgets/address_autocomplete_textfield.dart
+++ b/lib/widgets/address_autocomplete_textfield.dart
@@ -50,6 +50,10 @@ class AddressAutocompleteTextField extends AddresssAutocompleteStatefulWidget {
   @override
   final String mapsApiKey;
 
+  ///your proxy url for web
+  @override
+  final String? proxyUrl;
+
   ///builder used to render each item displayed
   ///must not be null
   @override
@@ -185,6 +189,7 @@ class AddressAutocompleteTextField extends AddresssAutocompleteStatefulWidget {
   const AddressAutocompleteTextField({
     super.key,
     required this.mapsApiKey,
+    this.proxyUrl,
     this.controller,
     this.focusNode,
     this.initialValue,

--- a/lib/widgets/address_autocomplete_textformfield.dart
+++ b/lib/widgets/address_autocomplete_textformfield.dart
@@ -54,6 +54,10 @@ class AddressAutocompleteTextFormField
   @override
   final String mapsApiKey;
 
+  ///your proxy url for web
+  @override
+  final String? proxyUrl;
+
   ///builder used to render each item displayed
   ///must not be null
   @override
@@ -229,6 +233,7 @@ class AddressAutocompleteTextFormField
   const AddressAutocompleteTextFormField({
     super.key,
     required this.mapsApiKey,
+    this.proxyUrl,
     this.controller,
     this.requiredField = false,
     this.validator = defaultValidator,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_maps_places_autocomplete_widgets
 description: TextField and TextFormField widgets using Google Maps Places Api for Address Autocompletion.
-version: 1.3.3
+version: 1.3.4
 homepage: https://github.com/timmaffett/google_maps_places_autocomplete_widgets
 repository: https://github.com/timmaffett/google_maps_places_autocomplete_widgets
 issue_tracker: https://github.com/timmaffett/google_maps_places_autocomplete_widgets/issues
@@ -26,8 +26,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  uuid: ^4.2.1
-  http: ^1.1.0
+  uuid: ^4.5.1
+  http: ^1.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Adding support for the package to use proxy urls to circumvent CORS issues when using Flutter Web.